### PR TITLE
Update AUV7 COG after ballast position change

### DIFF
--- a/src/proc_control/config/AUV7.yaml
+++ b/src/proc_control/config/AUV7.yaml
@@ -82,7 +82,7 @@
 
 
 # Center of mass              x     y     z
-/proc_control/physics/rg : '-0.0035, 0.001, 0.008' # distance (m) between center of mass and the geometric center of the sub.
+/proc_control/physics/rg : '-0.0035, -0.001, 0.008' # distance (m) between center of mass and the geometric center of the sub.
 
 # Center of boyency           x     y     z
 /proc_control/physics/rb : '0.00, 0.00, -0.004' # distance (m) between center of boyency and the geometric center of the sub.


### PR DESCRIPTION
## Description
The COG of the AUV7 was modified inside the AUV7 config file to correct the changed location of one of the ballasts. Repositioning of one ballast inside the AUV7 took place because it got loose during the transport between the hotel to the transdec and its exact previous location could not be determined. After the repostioning, the sub had a substantial lean to the front portside. 

## How has this been tested ?
The needed ajustemenet of the COG was determined experimentally in a training pool on the transdec. 

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings